### PR TITLE
Implement killer move heuristic.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ script:
   - make
   - make gtest
   - make coverage
+  - printf "bench\nquit\n" | ./goldfish.x
 
 after_success:
   - cd $PARENTDIR/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 cmake_minimum_required(VERSION 3.0)
 
 # Set project name here.
-project(Goldfish VERSION 1.5.1 LANGUAGES CXX)
+project(Goldfish VERSION 1.6.0 LANGUAGES CXX)
 
 
 # Include stuff. No change needed.

--- a/include/movelist.hpp
+++ b/include/movelist.hpp
@@ -26,6 +26,8 @@ public:
     void sort();
 
     void rate_from_Mvvlva();
+
+    void add_killer(Move m);
 };
 
 class MoveVariation {

--- a/src/movelist.cpp
+++ b/src/movelist.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+#include <cassert>
 #include "movelist.hpp"
 
 namespace goldfish {
@@ -25,6 +27,23 @@ void MoveList<T>::sort() {
 
         entries[j] = entry;
     }
+}
+
+/**
+ * Move the given move to the front of the array, keeping
+ * all others in the same order.
+ */
+template<class T>
+void MoveList<T>::add_killer(Move m) {
+    for (auto killer = entries.rbegin(); killer != entries.rend(); ++killer) {
+        if ((*killer)->move == m) {
+            // Right shift the subarray [begin, entry] by one shift.
+            std::rotate(killer, killer + 1, entries.rend());
+            return;
+        }
+    }
+    // The move should always be in the list.
+    assert(false);
 }
 
 /**

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -393,48 +393,45 @@ void Search::search_root(Depth depth, int alpha, int beta) {
 int Search::search(Depth depth, int alpha, int beta, int ply) {
     // Check TTable before anything else is done.
     auto entry = ttable.probe(position.zobrist_key);
-    if (entry != nullptr) {
-        if (entry->depth() >= depth) {
+    if (entry != nullptr and entry->depth() >= depth) {
+        switch (entry->bound()) {
 
-            switch (entry->bound()) {
+            case Bound::EXACT:
+                // In the case of exact scores, we can always return
+                // right away. Just update best move if we exceed alpha.
+                if (entry->value() > alpha)
+                    save_pv(entry->move(), pv[ply + 1], pv[ply]);
+                update_search(ply);
+                return entry->value();
 
-                case Bound::EXACT:
-                    // In the case of exact scores, we can always return
-                    // right away. Just update best move if we exceed alpha.
-                    if (entry->value() > alpha)
-                        save_pv(entry->move(), pv[ply + 1], pv[ply]);
-                    update_search(ply);
-                    return entry->value();
+            case Bound::LOWER:
+                // With a lower bound we check if we should update alpha.
+                // After all this we
+                if (entry->value() > alpha) {
+                    save_pv(entry->move(), pv[ply + 1], pv[ply]);
+                    alpha = entry->value();
 
-                case Bound::LOWER:
-                    // With a lower bound we check if we should update alpha.
-                    // After all this we
-                    if (entry->value() > alpha) {
-                        save_pv(entry->move(), pv[ply + 1], pv[ply]);
-                        alpha = entry->value();
-
-                        // Check for zero-size search window.
-                        if (entry->value() >= beta) {
-                            update_search(ply);
-                            return entry->value();
-                        }
-                    }
-                    break;
-
-                case Bound::UPPER:
-                    // For upper bounds, we can stop if the bound
-                    // is leq than alpha because no move will improve alpha.
-                    // If alpha < bound we have no usefull info, as the
-                    // exact value could still be less than alpha, so we
-                    // cannot update alpha and pv yet.
-                    if (entry->value() <= alpha) {
+                    // Check for zero-size search window.
+                    if (entry->value() >= beta) {
                         update_search(ply);
                         return entry->value();
                     }
-                    break;
-                default:
-                    throw std::exception();
-            }
+                }
+                break;
+
+            case Bound::UPPER:
+                // For upper bounds, we can stop if the bound
+                // is leq than alpha because no move will improve alpha.
+                // If alpha < bound we have no usefull info, as the
+                // exact value could still be less than alpha, so we
+                // cannot update alpha and pv yet.
+                if (entry->value() <= alpha) {
+                    update_search(ply);
+                    return entry->value();
+                }
+                break;
+            default:
+                throw std::exception();
         }
     }
 
@@ -500,6 +497,15 @@ int Search::search(Depth depth, int alpha, int beta, int ply) {
     }
 
     MoveList<MoveEntry> &moves = move_generators[ply].get_moves(position, depth, is_check);
+
+    // Killer Move Heuristic:
+    // If lookup didn't cause a cutoff, including if we don't have the required depth to use
+    // the table entry, lets use the stored move as a killer move,
+    // searching it first in the hopes that it will lead to more cutoffs.
+    if (entry != nullptr and entry->move() != Move::NO_MOVE) {
+        moves.add_killer(entry->move());
+    }
+
     for (int i = 0; i < moves.size; i++) {
         Move move = moves.entries[i]->move;
         int value = best_value;

--- a/tests/movelisttest.cpp
+++ b/tests/movelisttest.cpp
@@ -1,4 +1,5 @@
 #include "movelist.hpp"
+#include "move.hpp"
 
 #include "gtest/gtest.h"
 
@@ -7,7 +8,24 @@ using namespace goldfish;
 TEST(movelisttest, test) {
     MoveList <MoveEntry> move_list;
 
-    EXPECT_EQ(0, move_list.size);
-    move_list.entries[move_list.size++]->move = Move::NO_MOVE;
-    EXPECT_EQ(1, move_list.size);
+    Move m1 = Move::NO_MOVE;
+    Move m2 = Moves::value_of(MoveType::NORMAL, Square::A2, Square::A3, Piece::WHITE_PAWN, Piece::NO_PIECE, PieceType::NO_PIECE_TYPE);
+    Move m3 = Moves::value_of(MoveType::NORMAL, Square::A3, Square::A4, Piece::WHITE_PAWN, Piece::NO_PIECE, PieceType::NO_PIECE_TYPE);
+    Move m4 = Moves::value_of(MoveType::NORMAL, Square::A4, Square::A5, Piece::WHITE_PAWN, Piece::NO_PIECE, PieceType::NO_PIECE_TYPE);
+
+    ASSERT_EQ(0, move_list.size);
+    move_list.entries[move_list.size++]->move = m1;
+    ASSERT_EQ(1, move_list.size);
+    ASSERT_EQ(m1, move_list.entries[0]->move);
+    move_list.entries[move_list.size++]->move = m2;
+    move_list.entries[move_list.size++]->move = m3;
+    move_list.entries[move_list.size++]->move = m4;
+    ASSERT_EQ(4, move_list.size);
+    move_list.add_killer(m3);
+    ASSERT_EQ(m3, move_list.entries[0]->move);
+    ASSERT_EQ(m1, move_list.entries[1]->move);
+    ASSERT_EQ(m2, move_list.entries[2]->move);
+    ASSERT_EQ(m4, move_list.entries[3]->move);
+
+
 }


### PR DESCRIPTION
If a move from ttable is available, regardless of depth
requirement, we search this first in the hopes that this will
cause more cutoffs.

Makes a _huge_ impact on bench score. Very slightly lower nodes/second,
but speed is reduced by ~50%.

Average of 3 bench results on MacBook Air 2015:

v1.6.0:
===========================
Total time (ms) : 11530
Nodes searched  : 11924519
Nodes/second    : 1034217

v1.5.1:
===========================
Total time (ms) : 21660
Nodes searched  : 23289650
Nodes/second    : 1075221