### PR TITLE
Remove use of managed pointers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 cmake_minimum_required(VERSION 3.0)
 
 # Set project name here.
-project(Goldfish VERSION 1.12.0 LANGUAGES C CXX)
+project(Goldfish VERSION 1.12.1 LANGUAGES C CXX)
 
 # Include stuff. No change needed.
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")

--- a/app/bench.cpp
+++ b/app/bench.cpp
@@ -2,8 +2,8 @@
 #include <iostream>
 
 int main() {
-    std::unique_ptr<goldfish::Goldfish> engine(new goldfish::Goldfish());
-    engine->receive_initialize();
-    engine->receive_bench();
-    engine->receive_quit();
+    goldfish::Goldfish engine;
+    engine.receive_initialize();
+    engine.receive_bench();
+    engine.receive_quit();
 }

--- a/app/bench.cpp
+++ b/app/bench.cpp
@@ -1,7 +1,9 @@
 #include "goldfish.hpp"
+
 #include <iostream>
 
-int main() {
+int main()
+{
     goldfish::Goldfish engine;
     engine.receive_initialize();
     engine.receive_bench();

--- a/app/goldfish.cpp
+++ b/app/goldfish.cpp
@@ -2,6 +2,6 @@
 #include <iostream>
 
 int main() {
-    std::unique_ptr<goldfish::Goldfish> engine(new goldfish::Goldfish());
-    engine->run();
+    goldfish::Goldfish engine;
+    engine.run();
 }

--- a/app/goldfish.cpp
+++ b/app/goldfish.cpp
@@ -1,7 +1,9 @@
 #include "goldfish.hpp"
+
 #include <iostream>
 
-int main() {
+int main()
+{
     goldfish::Goldfish engine;
     engine.run();
 }

--- a/app/perft.cpp
+++ b/app/perft.cpp
@@ -3,6 +3,6 @@
 #include <iostream>
 
 int main() {
-    std::unique_ptr<goldfish::Perft> perft(new goldfish::Perft());
-    perft->run();
+    goldfish::Perft perft;
+    perft.run();
 }

--- a/app/perft.cpp
+++ b/app/perft.cpp
@@ -1,8 +1,11 @@
-#include "goldfish.hpp"
 #include "perft.hpp"
+
+#include "goldfish.hpp"
+
 #include <iostream>
 
-int main() {
+int main()
+{
     goldfish::Perft perft;
     perft.run();
 }

--- a/benchmark.py
+++ b/benchmark.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
         print("No release build directory found. Please setup build-release.")
         sys.exit(1)
 
-    time, nodes = [sorted(x)[1:-1] for x in np.array([run_bench() for _ in tqdm(range(10))]).T]
+    time, nodes = [sorted(x)[1:-1] for x in np.array([run_bench() for _ in tqdm(range(20))]).T]
     mtime, stdtime = np.mean(time), np.std(time)
     ci_time = mtime - 1.96 * stdtime, mtime + 1.96 * stdtime
     print("Times (ms):", time)

--- a/include/goldfish.hpp
+++ b/include/goldfish.hpp
@@ -9,6 +9,8 @@ namespace goldfish
 class Goldfish : public Protocol
 {
 public:
+    Goldfish() : search(*this) {}
+
     void run();
 
     void send_best_move(Move best_move, Move ponder_move) final;

--- a/include/goldfish.hpp
+++ b/include/goldfish.hpp
@@ -38,7 +38,7 @@ private:
     std::chrono::system_clock::time_point start_time;
     std::chrono::system_clock::time_point status_start_time;
 
-    Search search;
+    Search   search;
     Position current_position = Notation::to_position(Notation::STANDARDPOSITION);
 
     void receive_ready();

--- a/include/goldfish.hpp
+++ b/include/goldfish.hpp
@@ -4,8 +4,6 @@
 #include "protocol.hpp"
 #include "search.hpp"
 
-#include <memory>
-
 namespace goldfish
 {
 class Goldfish : public Protocol
@@ -37,12 +35,11 @@ public:
                    uint64_t         tb_hits) final;
 
 private:
-    std::unique_ptr<Search>               search = std::make_unique<Search>(*this);
     std::chrono::system_clock::time_point start_time;
     std::chrono::system_clock::time_point status_start_time;
 
-    std::unique_ptr<Position> current_position
-        = std::make_unique<Position>(Notation::to_position(Notation::STANDARDPOSITION));
+    Search search;
+    Position current_position = Notation::to_position(Notation::STANDARDPOSITION);
 
     void receive_ready();
 

--- a/include/movelist.hpp
+++ b/include/movelist.hpp
@@ -19,10 +19,10 @@ private:
     static const int MAX_MOVES = 256;
 
 public:
-    std::array<std::shared_ptr<T>, MAX_MOVES> entries;
-    int                                       size = 0;
+    std::array<T, MAX_MOVES> entries;
+    int                      size = 0;
 
-    MoveList();
+    MoveList() = default;
 
     void sort();
 

--- a/include/movelist.hpp
+++ b/include/movelist.hpp
@@ -4,7 +4,6 @@
 #include "value.hpp"
 
 #include <array>
-#include <memory>
 
 namespace goldfish
 {

--- a/include/search.hpp
+++ b/include/search.hpp
@@ -15,7 +15,6 @@
 
 namespace goldfish
 {
-
 // Stack struct keeps track of the information we need to remember from nodes
 // shallower and deeper in the tree during the search. The number of entries here
 // will likely grow as search becomes more sophisticated.
@@ -174,7 +173,12 @@ private:
 
     void save_pv(const Move move, const MoveVariation& src, MoveVariation& dest);
 
-    Value pv_search(Depth depth, Stack* ss, Value alpha, Value beta, int ply, int move_number);
+    Value pv_search(Depth  depth,
+                    Stack* ss,
+                    Value  alpha,
+                    Value  beta,
+                    int    ply,
+                    int    move_number);
 
     Value search_root(Depth depth, Stack* ss, Value alpha, Value beta);
 

--- a/include/search.hpp
+++ b/include/search.hpp
@@ -9,7 +9,6 @@
 
 #include <chrono>
 #include <condition_variable>
-#include <memory>
 #include <mutex>
 #include <thread>
 

--- a/include/tb.hpp
+++ b/include/tb.hpp
@@ -200,7 +200,7 @@ inline TableResult probe_root(const Position& pos, MoveList<Entry>& moves)
         {
             for (int j = optimal_move_count; j < moves.size; ++j)
             {
-                if (tbres.move_equal_to(moves.entries[j]->move))
+                if (tbres.move_equal_to(moves.entries[j].move))
                 {
                     std::swap(moves.entries[optimal_move_count], moves.entries[j]);
                     ++optimal_move_count;

--- a/include/value.hpp
+++ b/include/value.hpp
@@ -29,7 +29,7 @@ enum Value : int
 
     TEMPO = 1,
 
-    RAZOR_MARGIN = 600,
+    RAZOR_MARGIN    = 600,
     FUTILITY_MARGIN = 200,
 };
 

--- a/src/goldfish.cpp
+++ b/src/goldfish.cpp
@@ -291,20 +291,20 @@ void Goldfish::receive_go(std::istringstream& input)
         if (ponder)
         {
             search.new_ponder_search(current_position,
-                                      white_time_left,
-                                      white_time_increment,
-                                      black_time_left,
-                                      black_time_increment,
-                                      search_moves_toGo);
-        }
-        else
-        {
-            search.new_clock_search(current_position,
                                      white_time_left,
                                      white_time_increment,
                                      black_time_left,
                                      black_time_increment,
                                      search_moves_toGo);
+        }
+        else
+        {
+            search.new_clock_search(current_position,
+                                    white_time_left,
+                                    white_time_increment,
+                                    black_time_left,
+                                    black_time_increment,
+                                    search_moves_toGo);
         }
     }
 

--- a/src/goldfish.cpp
+++ b/src/goldfish.cpp
@@ -178,7 +178,7 @@ void Goldfish::receive_position(std::istringstream& input)
         bool found = false;
         for (int i = 0; i < moves.size; i++)
         {
-            Move move = moves.entries[i]->move;
+            Move move = moves.entries[i].move;
             if (Notation::from_move(move) == token)
             {
                 current_position->make_move(move);

--- a/src/goldfish.cpp
+++ b/src/goldfish.cpp
@@ -83,12 +83,12 @@ void Goldfish::receive_quit()
 {
     // We received a quit command. Stop calculating now and
     // cleanup!
-    search->quit();
+    search.quit();
 }
 
 void Goldfish::receive_initialize()
 {
-    search->stop();
+    search.stop();
 
     // We received an initialization request.
 
@@ -117,17 +117,17 @@ void Goldfish::receive_ready()
 
 void Goldfish::receive_new_game()
 {
-    search->stop();
+    search.stop();
 
     // We received a new game command.
 
     // Initialize per-game settings here.
-    *current_position = Notation::to_position(Notation::STANDARDPOSITION);
+    current_position = Notation::to_position(Notation::STANDARDPOSITION);
 }
 
 void Goldfish::receive_position(std::istringstream& input)
 {
-    search->stop();
+    search.stop();
 
     // We received an position command. Just setup the position.
 
@@ -135,7 +135,7 @@ void Goldfish::receive_position(std::istringstream& input)
     input >> token;
     if (token == "startpos")
     {
-        *current_position = Notation::to_position(Notation::STANDARDPOSITION);
+        current_position = Notation::to_position(Notation::STANDARDPOSITION);
 
         if (input >> token)
         {
@@ -161,7 +161,7 @@ void Goldfish::receive_position(std::istringstream& input)
             }
         }
 
-        *current_position = Notation::to_position(fen);
+        current_position = Notation::to_position(fen);
     }
     else
     {
@@ -174,14 +174,14 @@ void Goldfish::receive_position(std::istringstream& input)
     {
         // Verify moves
         MoveList<MoveEntry>& moves = move_generator.get_legal_moves(
-            *current_position, 1, current_position->is_check());
+            current_position, 1, current_position.is_check());
         bool found = false;
         for (int i = 0; i < moves.size; i++)
         {
             Move move = moves.entries[i].move;
             if (Notation::from_move(move) == token)
             {
-                current_position->make_move(move);
+                current_position.make_move(move);
                 found = true;
                 break;
             }
@@ -198,7 +198,7 @@ void Goldfish::receive_position(std::istringstream& input)
 
 void Goldfish::receive_go(std::istringstream& input)
 {
-    search->stop();
+    search.stop();
 
     // We received a start command. Extract all parameters from the
     // command and start the search.
@@ -209,7 +209,7 @@ void Goldfish::receive_go(std::istringstream& input)
         int search_depth;
         if (input >> search_depth)
         {
-            search->new_depth_search(*current_position, Depth(search_depth));
+            search.new_depth_search(current_position, Depth(search_depth));
         }
         else
         {
@@ -221,7 +221,7 @@ void Goldfish::receive_go(std::istringstream& input)
         uint64_t search_nodes;
         if (input >> search_nodes)
         {
-            search->new_nodes_search(*current_position, search_nodes);
+            search.new_nodes_search(current_position, search_nodes);
         }
     }
     else if (token == "movetime")
@@ -229,12 +229,12 @@ void Goldfish::receive_go(std::istringstream& input)
         uint64_t search_time;
         if (input >> search_time)
         {
-            search->new_time_search(*current_position, search_time);
+            search.new_time_search(current_position, search_time);
         }
     }
     else if (token == "infinite")
     {
-        search->new_infinite_search(*current_position);
+        search.new_infinite_search(current_position);
     }
     else
     {
@@ -290,7 +290,7 @@ void Goldfish::receive_go(std::istringstream& input)
 
         if (ponder)
         {
-            search->new_ponder_search(*current_position,
+            search.new_ponder_search(current_position,
                                       white_time_left,
                                       white_time_increment,
                                       black_time_left,
@@ -299,7 +299,7 @@ void Goldfish::receive_go(std::istringstream& input)
         }
         else
         {
-            search->new_clock_search(*current_position,
+            search.new_clock_search(current_position,
                                      white_time_left,
                                      white_time_increment,
                                      black_time_left,
@@ -309,7 +309,7 @@ void Goldfish::receive_go(std::istringstream& input)
     }
 
     // Go...
-    search->start();
+    search.start();
     start_time        = std::chrono::system_clock::now();
     status_start_time = start_time;
 }
@@ -317,13 +317,13 @@ void Goldfish::receive_go(std::istringstream& input)
 void Goldfish::receive_ponder_hit()
 {
     // We received a ponder hit command. Just call ponderhit().
-    search->ponderhit();
+    search.ponderhit();
 }
 
 void Goldfish::receive_stop()
 {
     // We received a stop command. If a search is running, stop it.
-    search->stop();
+    search.stop();
 }
 
 void Goldfish::receive_bench()
@@ -358,8 +358,8 @@ void Goldfish::receive_bench()
             std::cerr << "\nPosition: " << count++ << '/' << num_positions << std::endl;
 
             receive_go(is);
-            search->wait_for_finished();
-            total_nodes += search->get_total_nodes();
+            search.wait_for_finished();
+            total_nodes += search.get_total_nodes();
         }
         else if (token == "position")
             receive_position(is);

--- a/src/movegenerator.cpp
+++ b/src/movegenerator.cpp
@@ -13,12 +13,12 @@ MoveList<MoveEntry>&
     legal_moves.size = 0;
     for (int i = 0; i < size; i++)
     {
-        Move move = legal_moves.entries[i]->move;
+        Move move = legal_moves.entries[i].move;
 
         const_cast<Position&>(position).make_move(move);
         if (!position.is_check(~position.active_color))
         {
-            legal_moves.entries[legal_moves.size++]->move = move;
+            legal_moves.entries[legal_moves.size++].move = move;
         }
         const_cast<Position&>(position).undo_move(move);
     }
@@ -56,10 +56,10 @@ MoveList<MoveEntry>&
             moves.size = 0;
             for (int i = 0; i < size; i++)
             {
-                if (Moves::get_target_piece(moves.entries[i]->move) != Piece::NO_PIECE)
+                if (Moves::get_target_piece(moves.entries[i].move) != Piece::NO_PIECE)
                 {
                     // Add only capturing moves
-                    moves.entries[moves.size++]->move = moves.entries[i]->move;
+                    moves.entries[moves.size++].move = moves.entries[i].move;
                 }
             }
         }
@@ -132,7 +132,7 @@ void MoveGenerator::add_moves(MoveList<MoveEntry>&          list,
             if (target_piece == Piece::NO_PIECE)
             {
                 // quiet move
-                list.entries[list.size++]->move
+                list.entries[list.size++].move
                     = Moves::value_of(MoveType::NORMAL,
                                       origin_square,
                                       target_square,
@@ -152,7 +152,7 @@ void MoveGenerator::add_moves(MoveList<MoveEntry>&          list,
                 if (Pieces::get_color(target_piece) == opposite_color)
                 {
                     // capturing move
-                    list.entries[list.size++]->move
+                    list.entries[list.size++].move
                         = Moves::value_of(MoveType::NORMAL,
                                           origin_square,
                                           target_square,
@@ -197,28 +197,28 @@ void MoveGenerator::add_pawn_moves(MoveList<MoveEntry>& list,
                     {
                         // Pawn promotion capturing move
 
-                        list.entries[list.size++]->move
+                        list.entries[list.size++].move
                             = Moves::value_of(MoveType::PAWN_PROMOTION,
                                               pawn_square,
                                               target_square,
                                               pawn_piece,
                                               target_piece,
                                               PieceType::QUEEN);
-                        list.entries[list.size++]->move
+                        list.entries[list.size++].move
                             = Moves::value_of(MoveType::PAWN_PROMOTION,
                                               pawn_square,
                                               target_square,
                                               pawn_piece,
                                               target_piece,
                                               PieceType::ROOK);
-                        list.entries[list.size++]->move
+                        list.entries[list.size++].move
                             = Moves::value_of(MoveType::PAWN_PROMOTION,
                                               pawn_square,
                                               target_square,
                                               pawn_piece,
                                               target_piece,
                                               PieceType::BISHOP);
-                        list.entries[list.size++]->move
+                        list.entries[list.size++].move
                             = Moves::value_of(MoveType::PAWN_PROMOTION,
                                               pawn_square,
                                               target_square,
@@ -230,7 +230,7 @@ void MoveGenerator::add_pawn_moves(MoveList<MoveEntry>& list,
                     {
                         // Normal capturing move
 
-                        list.entries[list.size++]->move
+                        list.entries[list.size++].move
                             = Moves::value_of(MoveType::NORMAL,
                                               pawn_square,
                                               target_square,
@@ -249,7 +249,7 @@ void MoveGenerator::add_pawn_moves(MoveList<MoveEntry>& list,
                                                     : Direction::NORTH);
                 target_piece = position.board[capture_square];
 
-                list.entries[list.size++]->move
+                list.entries[list.size++].move
                     = Moves::value_of(MoveType::EN_PASSANT,
                                       pawn_square,
                                       target_square,
@@ -275,41 +275,41 @@ void MoveGenerator::add_pawn_moves(MoveList<MoveEntry>& list,
         {
             // Pawn promotion move
 
-            list.entries[list.size++]->move = Moves::value_of(MoveType::PAWN_PROMOTION,
-                                                              pawn_square,
-                                                              target_square,
-                                                              pawn_piece,
-                                                              Piece::NO_PIECE,
-                                                              PieceType::QUEEN);
-            list.entries[list.size++]->move = Moves::value_of(MoveType::PAWN_PROMOTION,
-                                                              pawn_square,
-                                                              target_square,
-                                                              pawn_piece,
-                                                              Piece::NO_PIECE,
-                                                              PieceType::ROOK);
-            list.entries[list.size++]->move = Moves::value_of(MoveType::PAWN_PROMOTION,
-                                                              pawn_square,
-                                                              target_square,
-                                                              pawn_piece,
-                                                              Piece::NO_PIECE,
-                                                              PieceType::BISHOP);
-            list.entries[list.size++]->move = Moves::value_of(MoveType::PAWN_PROMOTION,
-                                                              pawn_square,
-                                                              target_square,
-                                                              pawn_piece,
-                                                              Piece::NO_PIECE,
-                                                              PieceType::KNIGHT);
+            list.entries[list.size++].move = Moves::value_of(MoveType::PAWN_PROMOTION,
+                                                             pawn_square,
+                                                             target_square,
+                                                             pawn_piece,
+                                                             Piece::NO_PIECE,
+                                                             PieceType::QUEEN);
+            list.entries[list.size++].move = Moves::value_of(MoveType::PAWN_PROMOTION,
+                                                             pawn_square,
+                                                             target_square,
+                                                             pawn_piece,
+                                                             Piece::NO_PIECE,
+                                                             PieceType::ROOK);
+            list.entries[list.size++].move = Moves::value_of(MoveType::PAWN_PROMOTION,
+                                                             pawn_square,
+                                                             target_square,
+                                                             pawn_piece,
+                                                             Piece::NO_PIECE,
+                                                             PieceType::BISHOP);
+            list.entries[list.size++].move = Moves::value_of(MoveType::PAWN_PROMOTION,
+                                                             pawn_square,
+                                                             target_square,
+                                                             pawn_piece,
+                                                             Piece::NO_PIECE,
+                                                             PieceType::KNIGHT);
         }
         else
         {
             // Normal move
 
-            list.entries[list.size++]->move = Moves::value_of(MoveType::NORMAL,
-                                                              pawn_square,
-                                                              target_square,
-                                                              pawn_piece,
-                                                              Piece::NO_PIECE,
-                                                              PieceType::NO_PIECE_TYPE);
+            list.entries[list.size++].move = Moves::value_of(MoveType::NORMAL,
+                                                             pawn_square,
+                                                             target_square,
+                                                             pawn_piece,
+                                                             Piece::NO_PIECE,
+                                                             PieceType::NO_PIECE_TYPE);
 
             // Move another rank forward
             target_square += direction;
@@ -323,7 +323,7 @@ void MoveGenerator::add_pawn_moves(MoveList<MoveEntry>& list,
                 {
                     // Pawn double move
 
-                    list.entries[list.size++]->move
+                    list.entries[list.size++].move
                         = Moves::value_of(MoveType::PAWN_DOUBLE,
                                           pawn_square,
                                           target_square,
@@ -351,12 +351,12 @@ void MoveGenerator::add_castling_moves(MoveList<MoveEntry>& list,
             && position.board[Square::G1] == Piece::NO_PIECE
             && !position.is_attacked(Square::F1, Color::BLACK))
         {
-            list.entries[list.size++]->move = Moves::value_of(MoveType::CASTLING,
-                                                              king_square,
-                                                              Square::G1,
-                                                              king_piece,
-                                                              Piece::NO_PIECE,
-                                                              PieceType::NO_PIECE_TYPE);
+            list.entries[list.size++].move = Moves::value_of(MoveType::CASTLING,
+                                                             king_square,
+                                                             Square::G1,
+                                                             king_piece,
+                                                             Piece::NO_PIECE,
+                                                             PieceType::NO_PIECE_TYPE);
         }
         // Do not test c1 whether it is attacked as we will test it in is_legal()
         if ((position.castling_rights & Castling::WHITE_QUEEN_SIDE)
@@ -366,12 +366,12 @@ void MoveGenerator::add_castling_moves(MoveList<MoveEntry>& list,
             && position.board[Square::D1] == Piece::NO_PIECE
             && !position.is_attacked(Square::D1, Color::BLACK))
         {
-            list.entries[list.size++]->move = Moves::value_of(MoveType::CASTLING,
-                                                              king_square,
-                                                              Square::C1,
-                                                              king_piece,
-                                                              Piece::NO_PIECE,
-                                                              PieceType::NO_PIECE_TYPE);
+            list.entries[list.size++].move = Moves::value_of(MoveType::CASTLING,
+                                                             king_square,
+                                                             Square::C1,
+                                                             king_piece,
+                                                             Piece::NO_PIECE,
+                                                             PieceType::NO_PIECE_TYPE);
         }
     }
     else
@@ -383,12 +383,12 @@ void MoveGenerator::add_castling_moves(MoveList<MoveEntry>& list,
             && position.board[Square::G8] == Piece::NO_PIECE
             && !position.is_attacked(Square::F8, Color::WHITE))
         {
-            list.entries[list.size++]->move = Moves::value_of(MoveType::CASTLING,
-                                                              king_square,
-                                                              Square::G8,
-                                                              king_piece,
-                                                              Piece::NO_PIECE,
-                                                              PieceType::NO_PIECE_TYPE);
+            list.entries[list.size++].move = Moves::value_of(MoveType::CASTLING,
+                                                             king_square,
+                                                             Square::G8,
+                                                             king_piece,
+                                                             Piece::NO_PIECE,
+                                                             PieceType::NO_PIECE_TYPE);
         }
         // Do not test c8 whether it is attacked as we will test it in is_legal()
         if ((position.castling_rights & Castling::BLACK_QUEEN_SIDE)
@@ -398,12 +398,12 @@ void MoveGenerator::add_castling_moves(MoveList<MoveEntry>& list,
             && position.board[Square::D8] == Piece::NO_PIECE
             && !position.is_attacked(Square::D8, Color::WHITE))
         {
-            list.entries[list.size++]->move = Moves::value_of(MoveType::CASTLING,
-                                                              king_square,
-                                                              Square::C8,
-                                                              king_piece,
-                                                              Piece::NO_PIECE,
-                                                              PieceType::NO_PIECE_TYPE);
+            list.entries[list.size++].move = Moves::value_of(MoveType::CASTLING,
+                                                             king_square,
+                                                             Square::C8,
+                                                             king_piece,
+                                                             Piece::NO_PIECE,
+                                                             PieceType::NO_PIECE_TYPE);
         }
     }
 }

--- a/src/movelist.cpp
+++ b/src/movelist.cpp
@@ -13,7 +13,7 @@ void MoveList<T>::sort()
 {
     for (int i = 1; i < size; i++)
     {
-        const T& entry = entries[i];
+        const T entry = std::move(entries[i]);
 
         int j = i;
         while ((j > 0) && (entries[j - 1].value < entry.value))
@@ -22,7 +22,7 @@ void MoveList<T>::sort()
             j--;
         }
 
-        entries[j] = entry;
+        entries[j] = std::move(entry);
     }
 }
 

--- a/src/movelist.cpp
+++ b/src/movelist.cpp
@@ -5,15 +5,6 @@
 
 namespace goldfish
 {
-template <class T>
-MoveList<T>::MoveList()
-{
-    for (unsigned int i = 0; i < entries.size(); i++)
-    {
-        entries[i] = std::shared_ptr<T>(new T());
-    }
-}
-
 /**
  * Sorts the move list using a stable insertion sort.
  */
@@ -22,10 +13,10 @@ void MoveList<T>::sort()
 {
     for (int i = 1; i < size; i++)
     {
-        std::shared_ptr<T> entry(entries[i]);
+        const T& entry = entries[i];
 
         int j = i;
-        while ((j > 0) && (entries[j - 1]->value < entry->value))
+        while ((j > 0) && (entries[j - 1].value < entry.value))
         {
             entries[j] = entries[j - 1];
             j--;
@@ -44,7 +35,7 @@ void MoveList<T>::add_killer(Move m)
 {
     for (auto killer = entries.rbegin(); killer != entries.rend(); ++killer)
     {
-        if ((*killer)->move == m)
+        if ((*killer).move == m)
         {
             // Right shift the subarray [begin, entry] by one shift.
             std::rotate(killer, killer + 1, entries.rend());
@@ -64,7 +55,7 @@ void MoveList<T>::rate_from_Mvvlva()
 {
     for (int i = 0; i < size; i++)
     {
-        Move  move  = entries[i]->move;
+        Move  move  = entries[i].move;
         Value value = Value::ZERO;
 
         Value piece_type_value
@@ -77,7 +68,7 @@ void MoveList<T>::rate_from_Mvvlva()
             value += 10 * PieceTypes::get_value(Pieces::get_type(target));
         }
 
-        entries[i]->value = value;
+        entries[i].value = value;
     }
 }
 

--- a/src/perft.cpp
+++ b/src/perft.cpp
@@ -12,7 +12,7 @@ namespace goldfish
 void Perft::run()
 {
     Position position(Notation::to_position(Notation::STANDARDPOSITION));
-    int depth = MAX_DEPTH;
+    int      depth = MAX_DEPTH;
 
     std::cout << "Testing " << Notation::from_position(position) << " at depth "
               << depth << std::endl;

--- a/src/perft.cpp
+++ b/src/perft.cpp
@@ -70,7 +70,7 @@ uint64_t Perft::mini_max(int depth, Position& position, int ply)
     MoveList<MoveEntry>& moves = move_generator.get_moves(position, depth, is_check);
     for (int i = 0; i < moves.size; i++)
     {
-        Move move = moves.entries[i]->move;
+        Move move = moves.entries[i].move;
 
         position.make_move(move);
         if (!position.is_check(~position.active_color))

--- a/src/perft.cpp
+++ b/src/perft.cpp
@@ -11,15 +11,14 @@ namespace goldfish
 {
 void Perft::run()
 {
-    std::unique_ptr<Position> position(
-        new Position(Notation::to_position(Notation::STANDARDPOSITION)));
+    Position position(Notation::to_position(Notation::STANDARDPOSITION));
     int depth = MAX_DEPTH;
 
-    std::cout << "Testing " << Notation::from_position(*position) << " at depth "
+    std::cout << "Testing " << Notation::from_position(position) << " at depth "
               << depth << std::endl;
 
     auto     start_time = std::chrono::system_clock::now();
-    uint64_t result     = mini_max(depth, *position, 0);
+    uint64_t result     = mini_max(depth, position, 0);
     auto     end_time   = std::chrono::system_clock::now();
 
     auto duration = end_time - start_time;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -33,9 +33,9 @@ void Search::check_stop_conditions()
             else
 
                 // Check if we have a checkmate
-                if (Values::is_checkmate(root_moves.entries[0]->value)
+                if (Values::is_checkmate(root_moves.entries[0].value)
                     && current_depth >= Depth(Value::CHECKMATE
-                                              - std::abs(root_moves.entries[0]->value)))
+                                              - std::abs(root_moves.entries[0].value)))
             {
                 abort = true;
             }
@@ -90,10 +90,10 @@ void Search::run()
             = move_generators[0].get_legal_moves(position, 1, position.is_check());
         for (int i = 0; i < moves.size; i++)
         {
-            Move move                                        = moves.entries[i]->move;
-            root_moves.entries[root_moves.size]->move        = move;
-            root_moves.entries[root_moves.size]->pv.moves[0] = move;
-            root_moves.entries[root_moves.size]->pv.size     = 1;
+            Move move                                       = moves.entries[i].move;
+            root_moves.entries[root_moves.size].move        = move;
+            root_moves.entries[root_moves.size].pv.moves[0] = move;
+            root_moves.entries[root_moves.size].pv.size     = 1;
             root_moves.size++;
         }
 
@@ -159,10 +159,10 @@ void Search::run()
         Move ponder_move = Move::NO_MOVE;
         if (root_moves.size > 0)
         {
-            best_move = root_moves.entries[0]->move;
-            if (root_moves.entries[0]->pv.size >= 2)
+            best_move = root_moves.entries[0].move;
+            if (root_moves.entries[0].pv.size >= 2)
             {
-                ponder_move = root_moves.entries[0]->pv.moves[1];
+                ponder_move = root_moves.entries[0].pv.moves[1];
             }
         }
 
@@ -232,12 +232,12 @@ Value Search::search_root(Depth depth, Stack* ss, Value alpha, Value beta)
     // Reset all values, so the best move is pushed to the front
     for (int i = 0; i < root_moves.size; i++)
     {
-        root_moves.entries[i]->value = -Value::INFINITE;
+        root_moves.entries[i].value = -Value::INFINITE;
     }
 
     for (int i = 0; i < root_moves.size; i++)
     {
-        Move move = root_moves.entries[i]->move;
+        Move move = root_moves.entries[i].move;
 
         current_move        = move;
         current_move_number = i + 1;
@@ -268,10 +268,10 @@ Value Search::search_root(Depth depth, Stack* ss, Value alpha, Value beta)
             alpha = value;
 
             // We found a new best move
-            root_moves.entries[i]->value = value;
-            save_pv(move, pv[ply + 1], root_moves.entries[i]->pv);
+            root_moves.entries[i].value = value;
+            save_pv(move, pv[ply + 1], root_moves.entries[i].pv);
 
-            protocol.send_move(*root_moves.entries[i],
+            protocol.send_move(root_moves.entries[i],
                                current_depth,
                                current_max_depth,
                                total_nodes,
@@ -507,7 +507,7 @@ Value Search::search(Depth depth, Stack* ss, Value alpha, Value beta, int ply)
 
     for (int i = 0; i < moves.size; i++)
     {
-        Move  move  = moves.entries[i]->move;
+        Move  move  = moves.entries[i].move;
         Value value = best_value;
 
         position.make_move(move);
@@ -625,7 +625,7 @@ Value Search::quiescent(Stack* ss, Value alpha, Value beta, int ply)
         = move_generators[ply].get_moves(position, Depth::DEPTH_ZERO, is_check);
     for (int i = 0; i < moves.size; i++)
     {
-        Move  move  = moves.entries[i]->move;
+        Move  move  = moves.entries[i].move;
         Value value = best_value;
 
         position.make_move(move);

--- a/tests/movegeneratortest.cpp
+++ b/tests/movegeneratortest.cpp
@@ -301,13 +301,14 @@ uint64_t mini_max(Depth depth, Position& position, int ply)
 
     uint64_t total_nodes = 0;
 
-    bool                 is_check = position.is_check();
+    bool is_check = position.is_check();
+
+    auto                 temp = move_generators[ply];
     MoveList<MoveEntry>& moves
         = move_generators[ply].get_moves(position, depth, is_check);
-
     for (int i = 0; i < moves.size; i++)
     {
-        Move move = moves.entries[i]->move;
+        Move move = moves.entries[i].move;
 
         position.make_move(move);
         if (!position.is_check(~position.active_color))
@@ -334,7 +335,7 @@ TEST(movegeneratortest, test_perft)
                 Position position(Notation::to_position(p.fen));
 
                 uint64_t result = mini_max(depth, position, 0);
-                EXPECT_EQ(nodes, result)
+                ASSERT_EQ(nodes, result)
                     << Notation::from_position(position) << ", depth " << i
                     << ": expected " << nodes << ", actual " << result;
             }

--- a/tests/movelisttest.cpp
+++ b/tests/movelisttest.cpp
@@ -31,16 +31,16 @@ TEST(movelisttest, test)
                               PieceType::NO_PIECE_TYPE);
 
     ASSERT_EQ(0, move_list.size);
-    move_list.entries[move_list.size++]->move = m1;
+    move_list.entries[move_list.size++].move = m1;
     ASSERT_EQ(1, move_list.size);
-    ASSERT_EQ(m1, move_list.entries[0]->move);
-    move_list.entries[move_list.size++]->move = m2;
-    move_list.entries[move_list.size++]->move = m3;
-    move_list.entries[move_list.size++]->move = m4;
+    ASSERT_EQ(m1, move_list.entries[0].move);
+    move_list.entries[move_list.size++].move = m2;
+    move_list.entries[move_list.size++].move = m3;
+    move_list.entries[move_list.size++].move = m4;
     ASSERT_EQ(4, move_list.size);
     move_list.add_killer(m3);
-    ASSERT_EQ(m3, move_list.entries[0]->move);
-    ASSERT_EQ(m1, move_list.entries[1]->move);
-    ASSERT_EQ(m2, move_list.entries[2]->move);
-    ASSERT_EQ(m4, move_list.entries[3]->move);
+    ASSERT_EQ(m3, move_list.entries[0].move);
+    ASSERT_EQ(m1, move_list.entries[1].move);
+    ASSERT_EQ(m2, move_list.entries[2].move);
+    ASSERT_EQ(m4, move_list.entries[3].move);
 }


### PR DESCRIPTION
Leftovers from the fluxroot/pulse project, which had no purpose for being managed pointers what so ever. There are no needs for managed pointers (or much pointers at all) at the current point, so all of it has been removed. 

This does not affect the search in any way and shows a clear improvement in benchmarks. So this will be merged as soon as CI checks out, without play tests.