### PR TITLE
Fix draw-by-repetition detection

### DIFF
--- a/engine/src/board.rs
+++ b/engine/src/board.rs
@@ -23,7 +23,9 @@ pub trait BoardExt {
 
 impl BoardExt for Board {
     fn halfmove_reset(&self, mv: ChessMove) -> bool {
-        self.piece_on(mv.get_source()).unwrap() == Piece::Pawn
+        self.piece_on(mv.get_source())
+            .unwrap_or_else(|| panic!("error at {self} for {mv}"))
+            == Piece::Pawn
             || self.piece_on(mv.get_dest()).is_some()
     }
 

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -108,13 +108,14 @@ impl Engine {
                             .join(" ")
                     );
                     self.transposition_table.new_search();
-                    let (bm, logger) = Searcher::best_move(
+                    let (bm, logger) = Searcher::new(
                         &position,
                         &go_options,
                         interface.stop.clone(),
                         &mut self.transposition_table,
                         self.tablebase,
-                    );
+                    )
+                    .best_move();
 
                     println!("bestmove {bm}");
 

--- a/engine/src/search/mod.rs
+++ b/engine/src/search/mod.rs
@@ -18,6 +18,7 @@ use super::newtypes::Ply;
 use super::tt::TranspositionTable;
 use crate::board::BoardExt;
 use crate::evaluate::Evaluate;
+use crate::newtypes::Depth;
 use fathom::Tablebase;
 use stackstate::StackState;
 use uci::Position;
@@ -25,6 +26,7 @@ use uci::Position;
 #[derive(Debug)]
 pub struct Searcher<'a> {
     root_position: Board,
+    root_position_ply: Ply,
     ss: [StackState; Ply::MAX.as_usize() + 1],
     limits: Limits,
     logger: Logger,
@@ -41,37 +43,46 @@ pub const NON_PV_NODE: bool = false;
 
 impl<'a> Searcher<'a> {
     /// Create a new [`Searcher`].
-    pub fn best_move(
+    pub fn new(
         position: &Position,
         go_options: &[uci::GoOption],
         stop_signal: Arc<AtomicBool>,
         transposition_table: &'a mut TranspositionTable,
         tablebase: Option<&'static Tablebase>,
-    ) -> (ChessMove, Logger) {
-        let mut board = position.start_pos;
-        let mut root_position = board;
+    ) -> Self {
+        let mut root_position = position.start_pos;
         let mut halfmove_clock = position.starting_halfmove_clock;
-        for mv in &position.moves {
-            if board.halfmove_reset(*mv) {
-                halfmove_clock = 0;
-            } else {
-                halfmove_clock += 1;
-            }
-            board.make_move(*mv, &mut root_position);
-            board = root_position;
-        }
+        let mut root_position_ply = Ply::ZERO;
 
         let mut stack_states = [StackState::default(); Ply::MAX.as_usize() + 1];
         stack_states[0].eval = Some(root_position.evaluate());
         stack_states[0].zobrist = root_position.get_hash();
         stack_states[0].halfmove_clock = halfmove_clock;
 
+        for (i, mv) in position.moves.iter().enumerate() {
+            if root_position.halfmove_reset(*mv) {
+                halfmove_clock = 0;
+            } else {
+                halfmove_clock += 1;
+            }
+            root_position = root_position.make_move_new(*mv);
+            stack_states[i + 1].eval = Some(root_position.evaluate());
+            stack_states[i + 1].zobrist = root_position.get_hash();
+            stack_states[i + 1].halfmove_clock = halfmove_clock;
+
+            // Remember pre-root moves, but leave enough stack states for a max search depth.
+            if position.moves.len() - i < Depth::MAX.as_usize() {
+                root_position_ply = root_position_ply.increment();
+            }
+        }
+
         let root_moves: MoveVec = MoveGen::new_legal(&root_position).into();
         let logger = Logger::new().silent(go_options.iter().any(|o| *o == uci::GoOption::Silent));
         let limits = Limits::from(go_options).with_time_control(&root_position);
 
-        let mut searcher = Self {
+        Self {
             root_position,
+            root_position_ply,
             ss: stack_states,
             limits,
             logger,
@@ -80,9 +91,11 @@ impl<'a> Searcher<'a> {
             transposition_table,
             tablebase,
             history_stats: [[0; 64]; 64],
-        };
+        }
+    }
 
-        let bm = searcher.run();
-        (bm, searcher.logger)
+    pub fn best_move(mut self) -> (ChessMove, Logger) {
+        let bm = self.run();
+        (bm, self.logger)
     }
 }


### PR DESCRIPTION
It would not count pre-root moves in the detection, meaning it only found repetitions in-search. This should hopefully cause a _lot_ less draw-by-repetition in play tests, and less/no drawing in won positions.